### PR TITLE
[refact] #6 - 주문 품목 이력 조회 N+1 문제 해결 및 인덱싱 추가

### DIFF
--- a/.ebextensions/app.config
+++ b/.ebextensions/app.config
@@ -1,0 +1,12 @@
+files:
+    "/sbin/appstart" :
+        mode: "000755"
+        owner: webapp
+        group: webapp
+        content: |
+            #!/usr/bin/env bash
+            JAR_PATH=/var/app/current/application.jar
+
+            # run app
+            killall java
+            java -Dfile.encoding=UTF-8 -jar $JAR_PATH

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 ### ETC ###
 src/main/resources/application.yml
 src/main/resources/application-*.yml
+HANDOFF.md
+CLAUDE.md

--- a/.platform/nginx.conf
+++ b/.platform/nginx.conf
@@ -1,0 +1,59 @@
+user                    nginx;
+error_log               /var/log/nginx/error.log warn;
+pid                     /var/run/nginx.pid;
+worker_processes        auto;
+worker_rlimit_nofile    33282;
+
+events {
+    use epoll;
+    worker_connections  1024;
+    multi_accept on;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+  include       conf.d/*.conf;
+
+  map $http_upgrade $connection_upgrade {
+      default     "upgrade";
+  }
+
+  upstream springboot {
+    server 127.0.0.1:8080;   // 8080번으로 돌고 있는 백엔드 서버를 인지해라!
+    keepalive 1024;
+  }
+
+  server {
+      listen        80 default_server;
+      listen        [::]:80 default_server;
+
+      location / {
+          proxy_pass          http://springboot;
+          proxy_http_version  1.1;
+          proxy_set_header    Connection          $connection_upgrade;
+          proxy_set_header    Upgrade             $http_upgrade;
+
+          proxy_set_header    Host                $host;
+          proxy_set_header    X-Real-IP           $remote_addr;
+          proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;  // 로그분석 (어디서 유입, 차단하고 싶은 사람)
+          proxy_set_header    X-Forwarded-Proto   $scheme;
+          proxy_redirect      off;
+      }
+
+      access_log    /var/log/nginx/access.log main;
+
+      client_header_timeout 60;
+      client_body_timeout   60;
+      keepalive_timeout     60;
+      gzip                  off;
+
+      # Include the Elastic Beanstalk generated locations
+      include conf.d/elasticbeanstalk/healthd.conf;
+  }
+}

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -jar application.jar

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,34 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ec2-user/app/
+    overwrite: yes
+
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ec2-user
+    group: ec2-user
+
+hooks:
+  BeforeInstall:
+    - location: scripts/stop.sh
+      timeout: 60
+      runas: ec2-user
+
+  AfterInstall:
+    - location: scripts/set-permissions.sh
+      timeout: 60
+      runas: ec2-user
+
+  ApplicationStart:
+    - location: scripts/start.sh
+      timeout: 120
+      runas: ec2-user
+
+  # ValidateService 임시 비활성화 (디버깅용)
+  # ValidateService:
+  #   - location: scripts/health-check.sh
+  #     timeout: 180
+  #     runas: ec2-user

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     /* Database */
-//    runtimeOnly 'com.mysql:mysql-connector-j'
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+//    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     /* Swagger OpenAPI */
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'

--- a/src/main/resources/com/werp/sero/order/query/dao/SOMapper.xml
+++ b/src/main/resources/com/werp/sero/order/query/dao/SOMapper.xml
@@ -184,13 +184,13 @@
             D.total_price AS item_total_price,
 
             (SELECT IFNULL(SUM(F.available_stock), 0)
-             FROM warehouse_stock F
-                      INNER JOIN material E ON F.material_id = E.id
+             FROM material E
+             INNER JOIN warehouse_stock F ON E.id = F.material_id
              WHERE E.material_code = D.item_code) AS available_stock,
 
             GREATEST(D.quantity - (SELECT IFNULL(SUM(F.available_stock), 0)
-                                   FROM warehouse_stock F
-                                            INNER JOIN material E ON F.material_id = E.id
+                                   FROM material E
+                                   INNER JOIN warehouse_stock F ON E.id = F.material_id
                                    WHERE E.material_code = D.item_code), 0) AS production_request
 
         FROM sales_order A
@@ -245,20 +245,17 @@
         B.spec,
         B.unit,
         B.quantity AS order_quantity,
-        (SELECT IFNULL(SUM(E.available_stock), 0)
-        FROM material D
-        INNER JOIN warehouse_stock E ON D.id = E.material_id
-        WHERE D.material_code = B.item_code) AS available_stock,
+        IFNULL(STOCK.total_stock, 0) AS available_stock,
 
         <choose>
             <when test="isLatestOnly == true">
-                <!-- 누적 합계 계산 -->
-                IFNULL((SELECT SUM(H.pr_quantity) FROM sales_order_item_history H WHERE H.so_item_id = B.id), 0) AS pr_quantity,
-                IFNULL((SELECT SUM(H.pi_quantity) FROM sales_order_item_history H WHERE H.so_item_id = B.id), 0) AS pi_quantity,
-                IFNULL((SELECT SUM(H.gi_quantity) FROM sales_order_item_history H WHERE H.so_item_id = B.id), 0) AS gi_quantity,
-                IFNULL((SELECT SUM(H.shipped_quantity) FROM sales_order_item_history H WHERE H.so_item_id = B.id), 0) AS shipped_quantity,
-                IFNULL((SELECT SUM(H.do_quantity) FROM sales_order_item_history H WHERE H.so_item_id = B.id), 0) AS do_quantity,
-                IFNULL((SELECT SUM(H.completed_quantity) FROM sales_order_item_history H WHERE H.so_item_id = B.id), 0) AS completed_quantity,
+                <!-- 누적 합계 계산 (JOIN으로 개선) -->
+                IFNULL(HIST.total_pr, 0) AS pr_quantity,
+                IFNULL(HIST.total_pi, 0) AS pi_quantity,
+                IFNULL(HIST.total_gi, 0) AS gi_quantity,
+                IFNULL(HIST.total_shipped, 0) AS shipped_quantity,
+                IFNULL(HIST.total_do, 0) AS do_quantity,
+                IFNULL(HIST.total_completed, 0) AS completed_quantity,
             </when>
             <otherwise>
                 <!-- 개별 이력 조회 시에는 각 레코드의 값 -->
@@ -274,12 +271,33 @@
         FROM sales_order A
         INNER JOIN sales_order_item B ON A.id = B.so_id
 
+        <!-- available_stock JOIN (서브쿼리 제거) -->
+        LEFT JOIN (
+            SELECT M.material_code, SUM(WS.available_stock) AS total_stock
+            FROM material M
+            INNER JOIN warehouse_stock WS ON M.id = WS.material_id
+            GROUP BY M.material_code
+        ) STOCK ON STOCK.material_code = B.item_code
+
         <choose>
             <when test="isLatestOnly == true">
+                <!-- 누적 합계 JOIN (서브쿼리 6개 제거) -->
+                LEFT JOIN (
+                    SELECT
+                        so_item_id,
+                        SUM(pr_quantity) AS total_pr,
+                        SUM(pi_quantity) AS total_pi,
+                        SUM(gi_quantity) AS total_gi,
+                        SUM(shipped_quantity) AS total_shipped,
+                        SUM(do_quantity) AS total_do,
+                        SUM(completed_quantity) AS total_completed
+                    FROM sales_order_item_history
+                    GROUP BY so_item_id
+                ) HIST ON HIST.so_item_id = B.id
                 LEFT JOIN sales_order_item_history C ON C.id = (
-                SELECT MAX(id)
-                FROM sales_order_item_history
-                WHERE so_item_id = B.id
+                    SELECT MAX(id)
+                    FROM sales_order_item_history
+                    WHERE so_item_id = B.id
                 )
             </when>
             <otherwise>


### PR DESCRIPTION
- N+1 문제 JOIN 으로 개선
- INDEX 추가

## Pull Request
### ISSUE
- #6 

### Develop
주문 품목 이력 조회 API에서 품목 N개당 서브쿼리 7개가 실행되는 N+1 문제를 발견. 서브쿼리를 LEFT JOIN + GROUP BY로 통합하고, 누락된 인덱스를 추가.

### Test

## 테스트 환경
- **Performance Testing** Ngrinder
- **API**: `GET /orders/40/item-history/latest`
- **VUser**: 99명
- **테스트 시간**: 1분
- **품목 수**: 50개

## 문제점
- 품목당 서브쿼리 7개 실행 (7N+1 쿼리)
- `sales_order_item_history.so_item_id`에 인덱스 없음
- 품목 50개 기준 → 351개 쿼리 실행


## Before
<img width="1662" height="823" alt="image" src="https://github.com/user-attachments/assets/29df9e77-a62e-46e3-a192-fca06b9c5b1e" />

| 지표 | 값 |
|------|-----|
| **TPS** | 77.4 |
| **Peak TPS** | 102.5 |
| **평균 응답시간** | 1,352.72ms |

## After
<img width="1650" height="846" alt="image" src="https://github.com/user-attachments/assets/a2effaba-bbc3-445d-bc0d-9984f59ca520" />

| 지표 | 값 |
|------|-----|
| **TPS** | 139.0 |
| **Peak TPS** | 426.0 |
| **평균 응답시간** | 663.93ms |

## Before vs After 비교

| 지표 | Before | After | 변화 | 개선율 |
|------|--------|-------|------|--------|
| **TPS** | 77.4 | 139.0 | +61.6 | **+79.6%** |
| **Peak TPS** | 102.5 | 426.0 | +323.5 | **+315.6%** |
| **평균 응답시간** | 1,352.72ms | 663.93ms | -688.79ms | **-50.9%** |
| **처리량** | 3,612건 | 7,234건 | +3,622건 | **+100.3%** |
| **쿼리 수 (N=50)** | 351개 | 1개 | -350개 | **-99.7%** |

